### PR TITLE
Update cd path to serverless demo after cloning the Chime js sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The above step deploys a AWS CloudFormation stack that creates resources needed 
     ```
     cd ../
     git clone https://github.com/aws/amazon-chime-sdk-js
-    cd demos/serverless
+    cd amazon-chime-sdk-js/demos/serverless
     ```
 
 2. Deploy the demo using:


### PR DESCRIPTION
The instructions seem to be missing the base path when changing directories to the `demos/serverless` folder