### PR TITLE
Set SharedMemorySize in task container definition to prevent Firefox browser tab from crashing

### DIFF
--- a/templates/RecordingDemoCloudformationTemplate.yaml
+++ b/templates/RecordingDemoCloudformationTemplate.yaml
@@ -161,6 +161,8 @@ Resources:
                     Ref: AWS::Region
                   awslogs-stream-prefix:
                     Ref: ECSContainerName
+              LinuxParameters:
+                SharedMemorySize: 2048
 
   ECSCluster:
     Type: 'AWS::ECS::Cluster'


### PR DESCRIPTION

### Issue:
Firefox tab is crashing a lot when loading some cpu-heavy web application(Amazon Chime Live Event, known as AMA meeting) in ECS docker container, especially when enabling screenshare.


### What to change:
Set SharedMemorySize to 2048MB in ECS task container definition section of the CF template according to [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-linuxparameters.html).

This will increase the size of shared memory located at /dev/shm. By default, the size of /dev/shm is 64MB, which is not enough.

https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
https://discuss.circleci.com/t/insufficient-shared-memory-on-docker-containers/33218
