### PR TITLE
Reduce recording artifacts bucket name length

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There are multiple ways for [invoking a REST API in Amazon API Gateway](https://
 
     ![stop recording](https://github.com/aws-samples/amazon-chime-sdk-recording-demo/blob/master/resources/postman-app-stop-recording.png)
 
-2. Once the recording stops, open the AWS Console and navigate to Amazon S3. You will find a recording in the bucket `chime-meeting-sdk-<aws-account-id>-<region>-recording-artifacts`, with a key name YYYY/MM/DD/HH/<ISO8601time when meeting started>.mp4.
+2. Once the recording stops, open the AWS Console and navigate to Amazon S3. You will find a recording in the bucket `chime-meeting-sdk-<aws-account-id>-<region>-recordings`, with a key name YYYY/MM/DD/HH/<ISO8601time when meeting started>.mp4.
 
     ![recording artifacts](https://github.com/aws-samples/amazon-chime-sdk-recording-demo/blob/master/resources/recording-artifacts.png)
 

--- a/templates/RecordingDemoCloudformationTemplate.yaml
+++ b/templates/RecordingDemoCloudformationTemplate.yaml
@@ -76,7 +76,7 @@ Resources:
     Properties:
         AccessControl: BucketOwnerFullControl
         BucketName:
-          Fn::Join: ['', ['chime-meeting-sdk-', {Ref: 'AWS::AccountId'}, '-', {Ref: 'AWS::Region'}, '-recording-artifacts']]
+          Fn::Join: ['', ['chime-meeting-sdk-', {Ref: 'AWS::AccountId'}, '-', {Ref: 'AWS::Region'}, '-recordings']]
   RecordingDemoLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
*Description of changes:*

The recording artifacts bucket name generated by the CloudFormation stack is longer than 64 characters in certain region (e.g. ap-southeast-2) which leads to the following error when CloudFormation tries to create the bucket: "Bucket name should be between 3 and 63 characters long".

Renaming the bucket so the bucket name exceed 63 chars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
