### PR TITLE
Updated readme to add `npm install` command before deploy script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The above step deploys a AWS CloudFormation stack that creates resources needed 
     cd ../
     git clone https://github.com/aws/amazon-chime-sdk-js
     cd amazon-chime-sdk-js/demos/serverless
+    npm install
     ```
 
 2. Deploy the demo using:


### PR DESCRIPTION
Issue #: https://github.com/aws-samples/amazon-chime-sdk-recording-demo/issues/21

*Description of changes:*
Updated README to include `npm install` command before deploying serverless demo. 
Related commit https://github.com/aws/amazon-chime-sdk-js/commit/74828b5b4db4b9448a455c3ff36080e0d43eb1b1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
