### PR TITLE
Add --no-fail-on-empty-changeset flag for serverless deploy script

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -132,7 +132,7 @@ spawnOrFail('sam', ['package', '--s3-bucket', `${bucket}`,
 console.log('Deploying recording application');
 const output=spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--stack-name', `${stack}`,
                     '--parameter-overrides', `ECRDockerImageArn=${ecrDockerImageArn}`,
-                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`]);
+                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`, '--no-fail-on-empty-changeset']);
 console.log(output);
 
 const invokeUrl=spawnOrFail('aws', ['cloudformation', 'describe-stacks', '--stack-name', `${stack}`,


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
Updated the serverless application deploy script to add `--no-fail-on-empty-changeset` parameter to specify if the CLI should return a non-zero exit code if there are no changes to be made to the stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
