### PR TITLE
Fix (firefox:62): LIBDBUSMENU-GLIB-WARNING

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
 	curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	/usr/bin/apt-get update && \
 	/usr/bin/apt-get upgrade -y && \
+	/usr/bin/apt-get install dbus-x11 -y && \
 	/usr/bin/apt-get install -y nodejs pulseaudio xvfb firefox ffmpeg xdotool unzip
 
 COPY /recording /recording


### PR DESCRIPTION
Install dbus-x11 to fix the below warning in ECS Task log:
(firefox:62): LIBDBUSMENU-GLIB-WARNING **: 14:57:48.711: Unable to get session bus: Failed to execute child process ?dbus-launch? (No such file or directory)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
