### PR TITLE
Comma spacing best practice has been implemented

### DIFF
--- a/recording/record.js
+++ b/recording/record.js
@@ -68,7 +68,7 @@ transcodeStreamToOutput.stderr.on('data', data => {
 });
 
 const timestamp = new Date();
-const fileTimestamp = timestamp.toISOString().substring(0,19);
+const fileTimestamp = timestamp.toISOString().substring(0, 19);
 const year = timestamp.getFullYear();
 const month = timestamp.getMonth() + 1;
 const day = timestamp.getDate();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The best practice in comma spacing between parameters is to make it after each comma. Here, we found second parameter without any space. I have implemented just the best practice.

![comma-spacing-issue](https://user-images.githubusercontent.com/5427055/110465112-3722ad00-80fe-11eb-9f32-37e66f0de1a1.png)

Details about this best practice:
https://eslint.org/docs/rules/comma-spacing
https://standardjs.com/rules.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
