### PR TITLE
Update node version to 18 and ubuntu version to 20.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN /usr/bin/apt-get update && \
 	/usr/bin/apt-get install -y curl && \
-	curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+	curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
 	/usr/bin/apt-get update && \
 	/usr/bin/apt-get upgrade -y && \
 	/usr/bin/apt-get install -y nodejs pulseaudio xvfb firefox ffmpeg xdotool unzip


### PR DESCRIPTION
*Issue #, if available:*
"node . /deploy.js" with error.
`Error: Failed to create/update the stack: ********, Waiter StackCreateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "ROLLBACK_COMPLETE" at least once`

*Description of changes:*
Updated node version to 18 and changed ubuntu version to 20 along with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
